### PR TITLE
Changed structure so that enemies belong to room objects

### DIFF
--- a/src/entity.rs
+++ b/src/entity.rs
@@ -19,12 +19,14 @@ pub trait Health {
     fn death(&mut self) -> bool;
 }
 
+#[derive(Clone)]
 pub enum EnemyKind {
     Attack,
     Health,
     Speed
 }
 
+#[derive(Clone)]
 pub struct Enemy {
     pub pos: Vec2<f32>,
     pub hitbox: Vec2<u32>, // Hitbox where speed enemy takes damage.
@@ -34,8 +36,6 @@ pub struct Enemy {
     pub hp: i32,    //store the health for speed enemy
     pub m_hp: i32,
     pub movement_vec: Vec2<f32>,
-    pub cr: Vec2<i32>,
-    pub cf: usize,
     pub last_dir_update: Option< Instant >,
     pub kind: EnemyKind,
     pub death: bool,
@@ -66,7 +66,7 @@ impl Health for Enemy {
 }
 
 impl Enemy {
-    pub fn new(position: Vec2<f32>, kind: EnemyKind, cr: Vec2<i32>, cf: usize) -> Enemy {
+    pub fn new(position: Vec2<f32>, kind: EnemyKind) -> Enemy {
         Enemy {
             pos: position,
             hitbox: Vec2::new(40, 30),
@@ -75,8 +75,6 @@ impl Enemy {
             dir: Direction::Left,
             hp: 1,
             m_hp: 1,
-            cr: cr,
-            cf: cf,
             movement_vec: Vec2::new(-1.0, 0.0),
             last_dir_update: None,
             kind: kind,

--- a/src/floor.rs
+++ b/src/floor.rs
@@ -1,4 +1,6 @@
 use crate::room::*;
+use crate::entity::*;
+use crate::util::*;
 
 pub struct Floor {
 
@@ -56,6 +58,9 @@ impl Floor {
             ['W','W','W','W','W','W','W','W','D','W','W','W','W','W','W','W','W'], // 10
         ];
         rooms[3][4] = Box::new(Room::new_test_room(blueprint));
+        let mut enemies_34_fl0 = Vec::new();
+        enemies_34_fl0.push(Enemy::new(Vec2::new((LEFT_WALL + 12 * 64) as f32 + 32.0, (TOP_WALL + 7 * 64) as f32 + 40.0), EnemyKind::Speed));
+        rooms[3][4].add_enemies(enemies_34_fl0);
 
         // TOP LEFT ROOM
         blueprint = [
@@ -92,8 +97,9 @@ impl Floor {
             ['W','W','W','W','W','W','W','W','D','W','W','W','W','W','W','W','W'], // 10
         ];
         rooms[3][2] = Box::new(Room::new_test_room(blueprint));
-
-
+        let mut enemies_32_fl0 = Vec::new();
+        enemies_32_fl0.push(Enemy::new( Vec2::new((LEFT_WALL + 3 * 64) as f32 + 32.0, (TOP_WALL + 6 * 64) as f32 + 40.0), EnemyKind::Attack));
+        rooms[3][2].add_enemies(enemies_32_fl0);
 
 
         // LEFT MID ROOM
@@ -223,6 +229,7 @@ impl Floor {
 
         Floor { rooms }
     }
+
     pub fn test_floor_2() -> Floor {
         // Initialize all grid spaces with None
         let mut rooms: Vec<Vec<Box<Room>>> = Vec::with_capacity(8);
@@ -397,6 +404,9 @@ impl Floor {
             ['W','W','W','W','W','W','W','W','W','W','W','W','W','W','W','W','W'], // 10
         ];
         rooms[4][4] = Box::new(Room::new_test_room(blueprint));
+        let mut enemies_44_fl1 = Vec::new();
+        enemies_44_fl1.push(Enemy::new(Vec2::new((LEFT_WALL + 14 * 64) as f32 + 32.0, (TOP_WALL + 9 * 64) as f32 + 40.0), EnemyKind::Health));
+        rooms[4][4].add_enemies(enemies_44_fl1);
 
         // 1 ABOVE 1 LEFT
         blueprint = [

--- a/src/game.rs
+++ b/src/game.rs
@@ -3,14 +3,12 @@ use crate::player::*;
 use crate::map::*;
 use crate::room::*;
 use crate::util::*;
-use crate::entity::*;
 
 use std::time::Instant;
 
 pub struct Game {
     pub player: Player,
     pub map: Map,
-    pub enemies: Vec<Enemy>,
 
     // Current room
     pub cr: Vec2<i32>,
@@ -22,16 +20,11 @@ pub struct Game {
 
 impl Game {
     pub fn new() -> Game {
-        let mut enemies = Vec::new();
-        enemies.push(Enemy::new( Vec2::new((LEFT_WALL + 12 * 64) as f32 + 32.0, (TOP_WALL + 7 * 64) as f32 + 40.0), EnemyKind::Speed, Vec2::new(3,4), 0));
-        enemies.push(Enemy::new( Vec2::new((LEFT_WALL + 14 * 64) as f32 + 32.0, (TOP_WALL + 9 * 64) as f32 + 40.0), EnemyKind::Health, Vec2::new(4,4), 1));
-        enemies.push(Enemy::new( Vec2::new((LEFT_WALL + 3 * 64) as f32 + 32.0, (TOP_WALL + 6 * 64) as f32 + 40.0), EnemyKind::Attack, Vec2::new(4,3), 0));
         Game {
             player: Player::new(),
             map: Map::new(),
             cr: Vec2::new(3, 4),
             cf: 0,
-            enemies: enemies,
             init_time: Instant::now(),
             //cr: Vec2::new(1, 3),
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -205,11 +205,19 @@ impl Demo for Manager {
 
                     // Move player
                     self.game.player.update_pos(mov_vec);
-                    for enemy in self.game.enemies.iter_mut() {
-                        if enemy.cf == self.game.cf {
-                            enemy.update_pos();
-                        }
+                    let mut enemies = self.game.current_room().enemies.clone();
+
+                    match &mut enemies {
+                        Some( enemy_list ) => {
+                            for enemy in enemy_list.iter_mut() {
+                                enemy.update_pos();
+                            }
+                        },
+                        None => {}
                     }
+
+                    self.game.current_room_mut().enemies = enemies;
+                    
 
                     // Apply collision
                     self.collide();
@@ -288,78 +296,86 @@ impl Manager {
         // TODO: Goal is to generalize hitbox data into a trait so that we can condense logic
 
         // Maintain enemy bounds for the room and check player collisions
-        for enemy in self.game.enemies.iter_mut() {
-            enemy.pos.x = enemy.pos.x.clamp(LEFT_WALL as f32 + (enemy.walkbox.x * 4) as f32, RIGHT_WALL as f32 - (enemy.walkbox.x * 4) as f32);
-            enemy.pos.y = enemy.pos.y.clamp(TOP_WALL as f32 + (enemy.walkbox.y * 4) as f32, BOT_WALL as f32 - (enemy.walkbox.y * 4) as f32);
-
-            // If the test enemy is in the current room of the player...
-            if self.game.cf == enemy.cf && self.game.cr.x == enemy.cr.x && self.game.cr.y == enemy.cr.y && !enemy.death() {
-                // If the test enemy's walkbox intersects with the player walkbox...
-                let wb_test = enemy.get_walkbox_world();
-                let player_test = self.game.player.get_walkbox_world();
-
-                // Attempt at collision with attackbox
-                if self.game.player.is_attacking {
-                    let player_attack = self.game.player.get_attackbox_world();
-                    if wb_test.has_intersection(player_attack) {
-                        println!("Attack collided with enemy!");
-                        enemy.damage(1);
-
-                        //Absorb Enemy
-                        if enemy.power == true {
-                            match enemy.kind {
-                                EnemyKind::Health => {
-                                    self.game.player.plus_power_health();
-                                    println!("PowerupHealth is {}", self.game.player.power_up_vec[0]);
-                                    println!("Max Health is: {}", self.game.player.max_hp());
-                                },
-                                EnemyKind::Speed => {
-                                    self.game.player.plus_power_speed();
-                                    println!("PowerupSpeed is {}", self.game.player.power_up_vec[1]);
-                                },
-                                EnemyKind::Attack => {
-                                    self.game.player.plus_power_attack();
-                                    println!("PowerupAttack is {}", self.game.player.power_up_vec[2]);
-                                },
+        let mut enemies = self.game.current_room().enemies.clone();
+                    
+        match &mut enemies {
+            Some( enemy_list ) => {
+                for enemy in enemy_list.iter_mut() {
+                    enemy.pos.x = enemy.pos.x.clamp(LEFT_WALL as f32 + (enemy.walkbox.x * 4) as f32, RIGHT_WALL as f32 - (enemy.walkbox.x * 4) as f32);
+                    enemy.pos.y = enemy.pos.y.clamp(TOP_WALL as f32 + (enemy.walkbox.y * 4) as f32, BOT_WALL as f32 - (enemy.walkbox.y * 4) as f32);
+        
+                    // If the test enemy is in the current room of the player...
+                    if !enemy.death() {
+                        // If the test enemy's walkbox intersects with the player walkbox...
+                        let wb_test = enemy.get_walkbox_world();
+                        let player_test = self.game.player.get_walkbox_world();
+        
+                        // Attempt at collision with attackbox
+                        if self.game.player.is_attacking {
+                            let player_attack = self.game.player.get_attackbox_world();
+                            if wb_test.has_intersection(player_attack) {
+                                println!("Attack collided with enemy!");
+                                enemy.damage(1);
+        
+                                //Absorb Enemy
+                                if enemy.power == true {
+                                    match enemy.kind {
+                                        EnemyKind::Health => {
+                                            self.game.player.plus_power_health();
+                                            println!("PowerupHealth is {}", self.game.player.power_up_vec[0]);
+                                            println!("Max Health is: {}", self.game.player.max_hp());
+                                        },
+                                        EnemyKind::Speed => {
+                                            self.game.player.plus_power_speed();
+                                            println!("PowerupSpeed is {}", self.game.player.power_up_vec[1]);
+                                        },
+                                        EnemyKind::Attack => {
+                                            self.game.player.plus_power_attack();
+                                            println!("PowerupAttack is {}", self.game.player.power_up_vec[2]);
+                                        },
+                                    }
+                                    
+                                    enemy.power = false;
+                                }
                             }
-                            
-                            enemy.power = false;
+                        }
+        
+                        // Then there's a collision!
+                        if wb_test.has_intersection(player_test) {
+                            //Damage enemy also! For some reason
+                            //println!("Collision");
+                            //enemy.damage(1);
+                            // Check to see when the player was attacked last...
+                            match self.game.player.last_invincibility_time {
+                                // If there is an old invincibility time for the player,
+                                // see if the "invincibility window" has elapsed since then...
+                                Some( time ) => {
+                                    if time.elapsed() >= Duration::from_millis(1750) {
+                                        // If so, update the invincibility time and take damage to the player.
+                                        self.game.player.update_invincibility_time();
+                                        self.game.player.damage(1);
+                                    }
+                                },
+                                None => {
+                                    // Otherwise, take damage as there was
+                                    // no previous "invincibility window" to account for
+                                    self.game.player.update_invincibility_time();
+                                    self.game.player.damage(1);
+                                }
+                            }
+        
+                            // If the player is dead, update to the game over menu state
+                            if self.game.player.death() {
+                                self.menu = MenuState::GameOver;
+                            }
                         }
                     }
                 }
-
-                // Then there's a collision!
-                if wb_test.has_intersection(player_test) {
-                    //Damage enemy also! For some reason
-                    //println!("Collision");
-                    //enemy.damage(1);
-                    // Check to see when the player was attacked last...
-                    match self.game.player.last_invincibility_time {
-                        // If there is an old invincibility time for the player,
-                        // see if the "invincibility window" has elapsed since then...
-                        Some( time ) => {
-                            if time.elapsed() >= Duration::from_millis(1750) {
-                                // If so, update the invincibility time and take damage to the player.
-                                self.game.player.update_invincibility_time();
-                                self.game.player.damage(1);
-                            }
-                        },
-                        None => {
-                            // Otherwise, take damage as there was
-                            // no previous "invincibility window" to account for
-                            self.game.player.update_invincibility_time();
-                            self.game.player.damage(1);
-                        }
-                    }
-
-                    // If the player is dead, update to the game over menu state
-                    if self.game.player.death() {
-                        self.menu = MenuState::GameOver;
-                    }
-                }
-            }
+            },
+            None => {}
         }
 
+        self.game.current_room_mut().enemies = enemies;
 
         self.core.wincan.set_draw_color(Color::RGBA(128, 0, 0, 255));
         let mut x = 0;
@@ -653,21 +669,26 @@ impl Manager {
                 }
 
                 //self.draw_enemies(textures);
-                for enemy in self.game.enemies.iter_mut() {
-                    if self.game.cf == enemy.cf && self.game.cr.x == enemy.cr.x && self.game.cr.y == enemy.cr.y && !enemy.death() {
-                        let tex = match &enemy.kind {
-                            EnemyKind::Attack => &attack_idle,
-                            EnemyKind::Health => &health_idle,
-                            EnemyKind::Speed => &speed_idle
-                        };
-        
-                        self.core.wincan.copy(&tex, None,
-                            Rect::new(
-                                enemy.get_pos_x() - 35 + 4,
-                                enemy.get_pos_y() - 64 + (enemy.get_walkbox().height()/2) as i32,
-                                64, 64)
-                        )?;
-                    }
+                match &mut self.game.current_room_mut().enemies {
+                    Some( enemies ) => {
+                        for enemy in enemies.iter_mut()  {
+                            if !enemy.death() {
+                                let tex = match &enemy.kind {
+                                    EnemyKind::Attack => &attack_idle,
+                                    EnemyKind::Health => &health_idle,
+                                    EnemyKind::Speed => &speed_idle
+                                };
+                
+                                self.core.wincan.copy(&tex, None,
+                                    Rect::new(
+                                        enemy.get_pos_x() - 35 + 4,
+                                        enemy.get_pos_y() - 64 + (enemy.get_walkbox().height()/2) as i32,
+                                        64, 64)
+                                )?;
+                            }
+                        }
+                    },
+                    None => {}
                 }
 
                 // If the player was attacked, show a quick damage indicator ("-1" in red)
@@ -779,22 +800,28 @@ impl Manager {
                     // Draw player collision hitbox
                     self.core.wincan.set_draw_color(Color::RGBA(255, 0, 0, 255));
                     self.core.wincan.draw_rect(self.game.player.get_walkbox_world())?;
-                    for enemy in self.game.enemies.iter_mut() {
-                        if self.game.cf == enemy.cf && self.game.cr.x == enemy.cr.x && self.game.cr.y == enemy.cr.y && !enemy.death() {
-                            self.core.wincan.set_draw_color(Color::RGBA(255, 0, 0, 255));
-                            self.core.wincan.draw_rect(enemy.get_walkbox_world())?;
-        
-                            self.core.wincan.set_draw_color(Color::RGBA(128,128,255,255));
-                            self.core.wincan.draw_rect(
-                                Rect::new(
-                                    enemy.get_pos_x() - (enemy.get_hitbox_x()/2) as i32,
-                                    enemy.get_pos_y() - (enemy.get_hitbox_y()) as i32,
-                                    enemy.get_hitbox_x(),
-                                    enemy.get_hitbox_y()
-                                )
-                            )?;
-                        }
+                    match &mut self.game.current_room_mut().enemies {
+                        Some( enemies ) => {
+                            for enemy in enemies.iter_mut() {
+                                if !enemy.death() {
+                                    self.core.wincan.set_draw_color(Color::RGBA(255, 0, 0, 255));
+                                    self.core.wincan.draw_rect(enemy.get_walkbox_world())?;
+                
+                                    self.core.wincan.set_draw_color(Color::RGBA(128,128,255,255));
+                                    self.core.wincan.draw_rect(
+                                        Rect::new(
+                                            enemy.get_pos_x() - (enemy.get_hitbox_x()/2) as i32,
+                                            enemy.get_pos_y() - (enemy.get_hitbox_y()) as i32,
+                                            enemy.get_hitbox_x(),
+                                            enemy.get_hitbox_y()
+                                        )
+                                    )?;
+                                }
+                            }
+                        },
+                        None => {},                        
                     }
+                   
 
                     // Draw player damage hitbox
                     self.core.wincan.set_draw_color(Color::RGBA(128, 128, 255, 255));

--- a/src/room.rs
+++ b/src/room.rs
@@ -1,5 +1,6 @@
 use crate::util::*;
 use crate::tile::*;
+use crate::entity::*;
 
 pub const ROOM_WIDTH: i32 = 17;
 pub const ROOM_HEIGHT: i32 = 11;
@@ -9,6 +10,7 @@ pub struct Room {
     pub exists: bool,
     pub visited: bool,
     pub tiles: Vec<Vec<Box<dyn Tile>>>,
+    pub enemies: Option<Vec<Enemy>>,
 }
 
 /*
@@ -24,7 +26,7 @@ pub struct Room {
 impl Room {
     // Returns a room that the developer sets every tile of manually.
     pub fn non_room() -> Room {
-        Room { exists: false, visited: false, tiles: Vec::new() }
+        Room { exists: false, visited: false, tiles: Vec::new(), enemies: None }
 
     }
     pub fn new_test_room(blueprint: [[char; 17]; 11]) -> Room {
@@ -101,8 +103,11 @@ impl Room {
             exists: true,
             visited: false,
             tiles: tiles,
+            enemies: None
         }
+    }
 
-
+    pub fn add_enemies(&mut self, enemies: Vec<Enemy>) {
+        self.enemies = Some(enemies);
     }
 }


### PR DESCRIPTION
Enemies are now added to vectors when making the test rooms in floor.rs

In addition, logic was updated so that enemy processing is exclusive to the player's current room

Finally, I had to do some borrowing weirdness by cloning the enemy vector when applying collision rules. As a result, the enemies vector is replaced after each frame, but since the enemies are being processed sequentially and not synchronously (collision, **then** drawing), it should not matter.