### PR TITLE
Removed Option from enemy argument for rooms; removed red box around spike tile

### DIFF
--- a/src/room.rs
+++ b/src/room.rs
@@ -10,7 +10,7 @@ pub struct Room {
     pub exists: bool,
     pub visited: bool,
     pub tiles: Vec<Vec<Box<dyn Tile>>>,
-    pub enemies: Option<Vec<Enemy>>,
+    pub enemies: Vec<Enemy>,
 }
 
 /*
@@ -26,7 +26,7 @@ pub struct Room {
 impl Room {
     // Returns a room that the developer sets every tile of manually.
     pub fn non_room() -> Room {
-        Room { exists: false, visited: false, tiles: Vec::new(), enemies: None }
+        Room { exists: false, visited: false, tiles: Vec::new(), enemies: Vec::new() }
 
     }
     pub fn new_test_room(blueprint: [[char; 17]; 11]) -> Room {
@@ -105,11 +105,11 @@ impl Room {
             exists: true,
             visited: false,
             tiles: tiles,
-            enemies: None
+            enemies: Vec::new()
         }
     }
 
     pub fn add_enemies(&mut self, enemies: Vec<Enemy>) {
-        self.enemies = Some(enemies);
+        self.enemies = enemies;
     }
 }


### PR DESCRIPTION
After further consideration - there's really no need for Option here; if the vector is empty, that indicates no enemies in the room. Trimmed down logic as a result, down to one clone operation per frame (still not ideal but better than multiple clones/frame)

Also, removed red box from the spike tile because it seemed like a debug box.